### PR TITLE
Fix product search sql injection

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -20,8 +20,15 @@ export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
-      .then(([products]: any) => {
+        ProductModel.findAll({where: {
+            [Op.or]: [
+              {name: {[Op.like]: `%${criteria}%` } },
+              {description: {[Op.like]: `%${criteria}%` } }
+            ],
+            deletedAt: null
+          },
+          order: [['name', 'ASC']]
+        }).then((products) => {
         const dataString = JSON.stringify(products)
         if (challengeUtils.notSolved(challenges.unionSqlInjectionChallenge)) { // vuln-code-snippet hide-start
           let solved = true


### PR DESCRIPTION
### Description

The product search feature is vulnerable to SQL Injection. The search criteria provided by the user is directly embedded into a LIKE clause within a raw SQL query.

Resolved or fixed issue: #2 

Impact

An attacker can use this vulnerability to exfiltrate sensitive data from other tables using UNION SELECT statements. For example, a search term like ')) UNION SELECT id, email, password, '1', '2', '3', '4', '5', '6' FROM Users-- could return user credentials in the search results.

Proposed Remediation

Use the ORM's built-in abstraction for filtering, which automatically handles parameterization of the LIKE values.
