### PR TITLE
fix weak password hashing algorithm for storing user passwords

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -40,7 +40,12 @@ interface IAuthenticatedUsers {
   updateFrom: (req: Request, user: ResponseWithUser) => any
 }
 
-export const hash = (data: string) => crypto.createHash('md5').update(data).digest('hex')
+// export const hash = (data: string) => crypto.createHash('md5').update(data).digest('hex')
+const bcrypt = require('bcrypt');
+const saltRounds = 12;
+exports.hash = async (password) => {
+  return await bcrypt.hash(password, saltRounds);
+}
 export const hmac = (data: string) => crypto.createHmac('sha256', 'pa4qacea4VK9t9nGv7yZtwmj').update(data).digest('hex')
 
 export const cutOffPoisonNullByte = (str: string) => {


### PR DESCRIPTION
### Description

The application uses a weak hashing algorithm (MD5) for storing user passwords, which is susceptible to rainbow table attacks and rapid brute-forcing.

Resolved or fixed issue: #9 

Impact
If the database is compromised, attackers can easily crack the MD5 hashes to recover plain-text passwords for all users.

Proposed Remediation
Use a strong, slow, and salted hashing algorithm like Argon2 or bcrypt.